### PR TITLE
feat: Add VOD model and Postgres repository

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -26,4 +26,5 @@
 - [x] **(완료)** VOD 도메인 정의 (`VOD` 엔티티, `IVodRepository`, `IVodProcessingQueue`)
 - [x] **(완료)** `UpdateStreamStatus` 유스케이스 수정: 방송 종료 시 VOD 처리 작업 추가
 - [x] **(완료)** `RedisVodProcessingQueue` 구현
-- [ ] **(진행 중)** VOD 처리 워커 생성
+- [x] **(완료)** VOD 처리 워커 생성
+- [ ] **(진행 중)** VOD 데이터베이스 및 리포지토리 구현

--- a/prisma/migrations/20250917105113_add_vod_model/migration.sql
+++ b/prisma/migrations/20250917105113_add_vod_model/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "public"."Vod" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "thumbnailUrl" TEXT NOT NULL,
+    "videoUrl" TEXT NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "views" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "streamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "Vod_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Vod_streamId_key" ON "public"."Vod"("streamId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Vod" ADD CONSTRAINT "Vod_streamId_fkey" FOREIGN KEY ("streamId") REFERENCES "public"."Stream"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Vod" ADD CONSTRAINT "Vod_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   streamKey    String        @unique
   stream       Stream?
   chatMessages ChatMessage[]
+  vods         Vod[]
 }
 
 model Stream {
@@ -25,6 +26,7 @@ model Stream {
   user         User          @relation(fields: [userId], references: [id])
   userId       String        @unique // A user can have only one stream
   chatMessages ChatMessage[]
+  vod          Vod?
 }
 
 model ChatMessage {
@@ -36,3 +38,20 @@ model ChatMessage {
   user      User     @relation(fields: [userId], references: [id])
   userId    String
 }
+
+model Vod {
+  id           String   @id @default(cuid())
+  title        String
+  thumbnailUrl String
+  videoUrl     String
+  duration     Int
+  views        Int      @default(0)
+  createdAt    DateTime @default(now())
+
+  stream   Stream @relation(fields: [streamId], references: [id])
+  streamId String @unique // A stream can have only one VOD
+
+  user   User   @relation(fields: [userId], references: [id])
+  userId String
+}
+

--- a/src/infrastructure/persistence/postgres/repositories/PostgresVodRepository.ts
+++ b/src/infrastructure/persistence/postgres/repositories/PostgresVodRepository.ts
@@ -1,0 +1,64 @@
+import { PrismaClient } from '@prisma/client';
+import { IVodRepository } from '../../../../domain/repositories/IVodRepository';
+import { Vod } from '../../../../domain/entities/vod.entity';
+
+// This is a simplified mapping. In a real-world scenario, you might use a library like class-transformer.
+const toEntity = (dbVod: any): Vod => {
+  return new Vod({
+    id: dbVod.id,
+    streamId: dbVod.streamId,
+    userId: dbVod.userId,
+    title: dbVod.title,
+    thumbnailUrl: dbVod.thumbnailUrl,
+    videoUrl: dbVod.videoUrl,
+    duration: dbVod.duration,
+    createdAt: dbVod.createdAt,
+    views: dbVod.views,
+  });
+};
+
+export class PostgresVodRepository implements IVodRepository {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  async create(vod: Vod): Promise<Vod> {
+    const createdDbVod = await this.prisma.vod.create({
+      data: {
+        id: vod.id,
+        title: vod.title,
+        thumbnailUrl: vod.thumbnailUrl,
+        videoUrl: vod.videoUrl,
+        duration: vod.duration,
+        streamId: vod.streamId,
+        userId: vod.userId,
+      },
+    });
+    return toEntity(createdDbVod);
+  }
+
+  async findById(id: string): Promise<Vod | null> {
+    const dbVod = await this.prisma.vod.findUnique({ where: { id } });
+    return dbVod ? toEntity(dbVod) : null;
+  }
+
+  async findByUserId(userId: string): Promise<Vod[]> {
+    const dbVods = await this.prisma.vod.findMany({ where: { userId } });
+    return dbVods.map(toEntity);
+  }
+
+  async save(vod: Vod): Promise<void> {
+    await this.prisma.vod.update({
+      where: { id: vod.id },
+      data: {
+        title: vod.title,
+        thumbnailUrl: vod.thumbnailUrl,
+        videoUrl: vod.videoUrl,
+        duration: vod.duration,
+        views: vod.views,
+      },
+    });
+  }
+}


### PR DESCRIPTION
이 PR은 PLAN.md의 5단계 VOD 시스템 구현의 네 번째 단계를 수행합니다.

**주요 변경 사항:**
- `prisma/schema.prisma`에 `Vod` 모델 추가 및 관계 설정
- `add_vod_model` 데이터베이스 마이그레이션 생성
- `PostgresVodRepository` 구현

이 작업은 이슈 #16을 해결합니다.